### PR TITLE
feat: add script for sending broadcast messages, unsubscribe flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,7 @@ Install the dependencies:
 npm install
 ```
 
-Copy the `.env.example` file to `.env`.
-
-```bash
-cp .env.example .env
-```
+Replace the variables in `.env.example` with real values, and set them as variables in your local environment.
 
 Fill in your Twilio Account SID and auth token, which cam be found in the [Twilio console](https://www.twilio.com/console/) in the `.env` file.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -195,11 +195,6 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
-    "dotenv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
-    },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "airtable": "^0.9.0",
     "body-parser": "^1.19.0",
-    "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "twilio": "^3.49.0"
   }

--- a/src/airtableUtils.js
+++ b/src/airtableUtils.js
@@ -12,20 +12,32 @@ const base = new airtable({ apiKey: process.env.AIRTABLE_API_KEY }).base(
   process.env.AIRTABLE_BASE_ID
 );
 
-// other questions:
-// to remove participants, for unsubscribe purposes, do we actually remove them from the base?
-// or do we want to keep them around but add a column for deletion?
-// i don't knowwwwww
-// i guess we can keep people around just to have a historical record
+// should we have the table name set as an environment variable?
+// passing it in is more ~ f U n C T i O N a L ~ I suppose
 
+// returns a map of {phone, name} for all subscribed participants
 async function getAllSubscribedParticipants(base, tableName) {
-  // toDo: filter unsubscribed participants
+  const participants = new Map();
+
   const records = await base(tableName).select().all();
-  return records;
+  records.map((record) => {
+    // airtable doesn't have a boolean field type, which is weaksauce
+    // it has a "checkbox". ok sure that works.
+    // but. the api only returns the property for rows where the box is checked.
+
+    if (!record.fields.unsubscribed) {
+      // using the phone number as a key 'cuz it's guaranteed unique
+      // just like you, you special snowflake ❄️
+      participants.set(record.fields.phone, record.fields.name);
+      console.log(record.fields);
+    }
+  });
+  return participants;
 }
 
 (async function () {
   const participants = await getAllSubscribedParticipants(base, "test");
-
-  console.log("participants", participants);
+  for (let [key, value] of participants) {
+    console.log(key, value);
+  }
 })();

--- a/src/airtableUtils.js
+++ b/src/airtableUtils.js
@@ -1,0 +1,50 @@
+if (process.env.NODE_ENV !== "production") {
+  // note: dotenv won't override existing environment variables
+  require("dotenv").config();
+}
+
+const airtable = require("airtable");
+
+// do i need to memoize this const?
+// idk how computationally expensive it is, or if having multiple base instances causes problems.
+// it probably doesn't matter and i am over thinking it 🤷🏻‍♂️
+const base = new airtable({ apiKey: process.env.AIRTABLE_API_KEY }).base(
+  process.env.AIRTABLE_BASE_ID
+);
+
+// other questions:
+// to remove participants, for unsubscribe purposes, do we actually remove them from the base?
+// or do we want to keep them around but add a column for deletion?
+// i don't knowwwwww
+// i guess we can keep people around just to have a historical record
+
+function getAllSubscribedParticipants(base, tableName) {
+  return base(tableName)
+    .select({
+      view: "Grid view",
+    })
+    .eachPage(
+      function page(records, fetchNextPage) {
+        // toDo: filter unsubscribed participants
+
+        records.forEach(function (record) {
+          console.log("Retrieved", record.get("name"), record.get("phone"));
+        });
+
+        // To fetch the next page of records, call `fetchNextPage`.
+        // If there are more records, `page` will get called again.
+        // If there are no more records, `done` will get called.
+        fetchNextPage();
+      },
+      function done(err) {
+        if (err) {
+          console.error(err);
+          return;
+        }
+      }
+    );
+}
+
+(async function () {
+  await getAllSubscribedParticipants(base, "test");
+})();

--- a/src/airtableUtils.js
+++ b/src/airtableUtils.js
@@ -1,10 +1,12 @@
 const airtable = require("airtable");
 
 // TODO: change this before you merge!!
+// this const is so that we can easily read/write from a test table under development
+// and not mess with "prod" data.
+// change this const to "participants" when you're ready to party.
 const tableName = "test";
 
 // to do:
-// consider how code is shared between utils, server, and scripts
 // rip out dotenv related code
 // TEST SUBSCRIBE FLOW TO MAKE SURE IT STILL WORKS
 // test error handling in case of an unsuccessful unsubscribe
@@ -22,10 +24,8 @@ const getBase = () => {
   return base;
 };
 
-// should we have the table name set as an environment variable?
-// passing it in is more ~ f U n C T i O N a L ~ I suppose
-
-// returns a map of {phone, {name: 'tilde', airtableRecordId: '12345'} for all subscribed participants
+// returns a map of {"+15555555", {name: 'tilde', airtableRecordId: '12345'} for all subscribed participants
+// phone numbers as always in e.164 format cuz I've got STANDARDS ok
 async function getAllSubscribedParticipants(base, tableName) {
   const participants = new Map();
 

--- a/src/airtableUtils.js
+++ b/src/airtableUtils.js
@@ -1,16 +1,23 @@
-if (process.env.NODE_ENV !== "production") {
-  // note: dotenv won't override existing environment variables
-  require("dotenv").config();
-}
-
 const airtable = require("airtable");
 
-// do i need to memoize this const?
-// idk how computationally expensive it is, or if having multiple base instances causes problems.
-// it probably doesn't matter and i am over thinking it 🤷🏻‍♂️
-const base = new airtable({ apiKey: process.env.AIRTABLE_API_KEY }).base(
-  process.env.AIRTABLE_BASE_ID
-);
+// to do:
+// add function for writing an unsubscribe to airtable
+// add an api endpoint for the same, and hook it up to the function
+// consider how code is shared between utils, server, and scripts
+// rip out dotenv related code
+// will implement group chat in a separate / future PR
+
+// memoize this because why the fuck not
+//  THERE CAN BE ONLY ONE BASE
+let base = null;
+const getBase = () => {
+  base
+    ? null
+    : (base = new airtable({ apiKey: process.env.AIRTABLE_API_KEY }).base(
+        process.env.AIRTABLE_BASE_ID
+      ));
+  return base;
+};
 
 // should we have the table name set as an environment variable?
 // passing it in is more ~ f U n C T i O N a L ~ I suppose
@@ -35,9 +42,4 @@ async function getAllSubscribedParticipants(base, tableName) {
   return participants;
 }
 
-(async function () {
-  const participants = await getAllSubscribedParticipants(base, "test");
-  for (let [key, value] of participants) {
-    console.log(key, value);
-  }
-})();
+module.exports = { getAllSubscribedParticipants, getBase, tableName: "test" };

--- a/src/airtableUtils.js
+++ b/src/airtableUtils.js
@@ -18,33 +18,14 @@ const base = new airtable({ apiKey: process.env.AIRTABLE_API_KEY }).base(
 // i don't knowwwwww
 // i guess we can keep people around just to have a historical record
 
-function getAllSubscribedParticipants(base, tableName) {
-  return base(tableName)
-    .select({
-      view: "Grid view",
-    })
-    .eachPage(
-      function page(records, fetchNextPage) {
-        // toDo: filter unsubscribed participants
-
-        records.forEach(function (record) {
-          console.log("Retrieved", record.get("name"), record.get("phone"));
-        });
-
-        // To fetch the next page of records, call `fetchNextPage`.
-        // If there are more records, `page` will get called again.
-        // If there are no more records, `done` will get called.
-        fetchNextPage();
-      },
-      function done(err) {
-        if (err) {
-          console.error(err);
-          return;
-        }
-      }
-    );
+async function getAllSubscribedParticipants(base, tableName) {
+  // toDo: filter unsubscribed participants
+  const records = await base(tableName).select().all();
+  return records;
 }
 
 (async function () {
-  await getAllSubscribedParticipants(base, "test");
+  const participants = await getAllSubscribedParticipants(base, "test");
+
+  console.log("participants", participants);
 })();

--- a/src/airtableUtils.js
+++ b/src/airtableUtils.js
@@ -4,9 +4,10 @@ const airtable = require("airtable");
 const tableName = "test";
 
 // to do:
-// add an api endpoint for the same, and hook it up to the function
 // consider how code is shared between utils, server, and scripts
 // rip out dotenv related code
+// TEST SUBSCRIBE FLOW TO MAKE SURE IT STILL WORKS
+// test error handling in case of an unsuccessful unsubscribe
 // will implement group chat in a separate / future PR
 
 // memoize this because why the fuck not
@@ -24,7 +25,7 @@ const getBase = () => {
 // should we have the table name set as an environment variable?
 // passing it in is more ~ f U n C T i O N a L ~ I suppose
 
-// returns a map of {phone, name} for all subscribed participants
+// returns a map of {phone, {name: 'tilde', airtableRecordId: '12345'} for all subscribed participants
 async function getAllSubscribedParticipants(base, tableName) {
   const participants = new Map();
 
@@ -37,39 +38,47 @@ async function getAllSubscribedParticipants(base, tableName) {
     // but. the api only returns the property for rows where the box is checked.
 
     if (!record.fields.unsubscribed) {
-      // using the phone number as a key 'cuz it's guaranteed unique
+      // using the phone number as a key 'cuz it should be guaranteed unique
       // just like you, you special snowflake ❄️
-      participants.set(record.fields.phone, record.fields.name);
+      participants.set(record.fields.phone, {
+        name: record.fields.name,
+        airtableRecordId: record.id,
+      });
     }
   });
   return participants;
 }
 
-async function unsubscribeParticipant(phoneNumber, base) {
-  // remove participant from map?
-  // (maybe map should be a singleton?) or maybe just let the server deal with that
-  // fetch existing record(s) because we need the IDs
-  // there could be multiple because people can sign up twice
+async function unsubscribeParticipant(phoneNumber, base, participantMap) {
+  if (!participantMap) {
+    // the server will have a cached version of the participant map
+    // might call this function from offline scripts tho, IDK
+    participantMap = await getAllSubscribedParticipants(base, tableName);
+  }
 
-  const records = await base(tableName).select().all();
-  // does map handle async stuff ok? I hate JS sometimes
+  const participant = participantMap.get(phoneNumber);
+  const airtableRecordId = participant["airtableRecordId"];
+  if (!airtableRecordId) {
+    throw new Error(`participant ${phoneNumber} not found`);
+  }
 
-  records.map(async (record) => {
-    if (record.fields.phone === phoneNumber) {
-      await base(tableName).update(
-        record.id,
-        { unsubscribed: true },
-        (error, record) => {
-          if (error) {
-            console.error(error);
-          } else {
-            console.log(`${record.fields.name} has been unsubscribed`);
-            // todo: should we message the person letting them know their unsubscribe was successful?
-          }
-        }
-      );
+  await base(tableName).update(
+    airtableRecordId,
+    { unsubscribed: true },
+    (error, record) => {
+      if (error) {
+        console.error(error);
+      } else {
+        console.log(`${record.fields.name} has been unsubscribed`);
+        // todo: message the person letting them know their unsubscribe was successful?
+      }
     }
-  });
+  );
 }
 
-module.exports = { getAllSubscribedParticipants, getBase, tableName };
+module.exports = {
+  getAllSubscribedParticipants,
+  getBase,
+  tableName,
+  unsubscribeParticipant,
+};

--- a/src/scripts/broadcastSMS.js
+++ b/src/scripts/broadcastSMS.js
@@ -3,7 +3,7 @@ const {
   getAllSubscribedParticipants,
   getBase,
   tableName,
-} = require("../airtableUtils");
+} = require("../utils");
 
 const twilioClient = twilio(
   process.env.TWILIO_ACCOUNT_SID,

--- a/src/scripts/broadcastSMS.js
+++ b/src/scripts/broadcastSMS.js
@@ -1,0 +1,31 @@
+const twilio = require("twilio");
+const {
+  getAllSubscribedParticipants,
+  getBase,
+  tableName,
+} = require("../airtableUtils");
+
+const twilioClient = twilio(
+  process.env.TWILIO_ACCOUNT_SID,
+  process.env.TWILIO_AUTH_TOKEN
+);
+
+const twilioNumber = "+1 415 430 9656";
+
+async function broadcastSMS() {
+  const participants = await getAllSubscribedParticipants(getBase(), tableName);
+  for (const [phoneNumber, name] of participants) {
+    // replace this with whatever message text you wanna send
+    const body = `hay hay ${name}`;
+    await twilioClient.messages.create({
+      to: phoneNumber,
+      from: twilioNumber,
+      body,
+    });
+    console.log(`message sent to ${name}`);
+  }
+}
+
+(async function () {
+  await broadcastSMS();
+})();

--- a/src/server.js
+++ b/src/server.js
@@ -6,7 +6,11 @@ if (process.env.NODE_ENV !== "production") {
 const bodyParser = require("body-parser");
 const http = require("http");
 const express = require("express");
-const airtable = require("airtable");
+const {
+  getBase,
+  tableName,
+  unsubscribeParticipant,
+} = require("./airtableUtils");
 
 const app = express();
 
@@ -14,9 +18,7 @@ app.use(bodyParser.json());
 
 app.use(express.static(__dirname + "/public"));
 
-const base = new airtable({ apiKey: process.env.AIRTABLE_API_KEY }).base(
-  process.env.AIRTABLE_BASE_ID
-);
+const base = getBase();
 
 // add a new participant to the Airtable base
 app.post("/api/participants", (request, response) => {
@@ -35,6 +37,19 @@ app.post("/api/participants", (request, response) => {
       }
     }
   );
+});
+
+// this isn't proper RESTful API design
+// but you can only GET and POST with twilio studio anyway
+// and I'm kind of out of fucks at the moment so YOLO
+app.post("/api/participants/unsubscribe", async (request, response) => {
+  try {
+    await unsubscribeParticipant(request.body.phone, base);
+  } catch (error) {
+    console.error("airtable request failed", error);
+    response.status(500).send(error);
+  }
+  response.status(200).send("successful unsubscribe");
 });
 
 // palindromes aren't loops but at least they take you back to the beginning.

--- a/src/server.js
+++ b/src/server.js
@@ -6,11 +6,7 @@ if (process.env.NODE_ENV !== "production") {
 const bodyParser = require("body-parser");
 const http = require("http");
 const express = require("express");
-const {
-  getBase,
-  tableName,
-  unsubscribeParticipant,
-} = require("./airtableUtils");
+const { getBase, tableName, unsubscribeParticipant } = require("./utils");
 
 const app = express();
 

--- a/src/server.js
+++ b/src/server.js
@@ -18,7 +18,7 @@ const base = getBase();
 
 // add a new participant to the Airtable base
 app.post("/api/participants", (request, response) => {
-  base("participants").create(
+  base(tableName).create(
     [
       {
         fields: request.body,

--- a/src/server.js
+++ b/src/server.js
@@ -38,12 +38,12 @@ app.post("/api/participants", (request, response) => {
 // this isn't proper RESTful API design
 // but you can only GET and POST with twilio studio anyway
 // and I'm kind of out of fucks at the moment so YOLO
-app.post("/api/participants/unsubscribe", async (request, response) => {
+app.post("/api/participants/unsubscribe", async (request, response, next) => {
   try {
     await unsubscribeParticipant(request.body.phone, base);
   } catch (error) {
     console.error("airtable request failed", error);
-    response.status(500).send(error);
+    return next(error);
   }
   response.status(200).send("successful unsubscribe");
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,7 +11,6 @@ const tableName = "test";
 // to do:
 // rip out dotenv related code
 // TEST SUBSCRIBE FLOW TO MAKE SURE IT STILL WORKS
-// test error handling in case of an unsuccessful unsubscribe
 // will implement group chat in a separate / future PR
 
 // memoize this because why the fuck not

--- a/src/utils.js
+++ b/src/utils.js
@@ -73,10 +73,11 @@ async function unsubscribeParticipant(phoneNumber, base, participantMap) {
   }
 
   const participant = participantMap.get(phoneNumber);
-  const airtableRecordId = participant["airtableRecordId"];
-  if (!airtableRecordId) {
+  if (!participant) {
     throw new Error(`participant ${phoneNumber} not found`);
   }
+
+  const airtableRecordId = participant["airtableRecordId"];
 
   await base(tableName).update(
     airtableRecordId,
@@ -84,6 +85,11 @@ async function unsubscribeParticipant(phoneNumber, base, participantMap) {
     async (error, record) => {
       if (error) {
         console.error(error);
+        await sendSingleSMS(
+          phoneNumber,
+          "sorry, the unsubscribe failed. Mind trying again in a few minutes?"
+        );
+        throw error;
       } else {
         participantMap.delete(phoneNumber);
         console.log(`${record.fields.name} has been unsubscribed`);

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,4 @@
+// like any good utils file, this is basically the junk drawer of the application
 const airtable = require("airtable");
 
 // TODO: change this before you merge!!

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,10 +6,7 @@ const twilio = require("twilio");
 // this const is so that we can easily read/write from a test table under development
 // and not mess with "prod" data.
 // change this const to "participants" when you're ready to party.
-const tableName = "test";
-
-// to do:
-// will implement group chat in a separate / future PR
+const tableName = "participants";
 
 // memoize this because why the fuck not
 //  THERE CAN BE ONLY ONE BASE
@@ -69,9 +66,11 @@ async function unsubscribeParticipant(phoneNumber, base, participantMap) {
     participantMap = await getAllSubscribedParticipants(base, tableName);
   }
 
-  const participant = participantMap.get(phoneNumber);
+  const trimmedNumber = phoneNumber.trim();
+
+  const participant = participantMap.get(trimmedNumber);
   if (!participant) {
-    throw new Error(`participant ${phoneNumber} not found`);
+    throw new Error(`participant ${trimmedNumber} not found`);
   }
 
   const airtableRecordId = participant["airtableRecordId"];
@@ -83,12 +82,12 @@ async function unsubscribeParticipant(phoneNumber, base, participantMap) {
       if (error) {
         console.error(error);
         await sendSingleSMS(
-          phoneNumber,
+          trimmedNumber,
           "sorry, the unsubscribe failed. Mind trying again in a few minutes?"
         );
         throw error;
       } else {
-        participantMap.delete(phoneNumber);
+        participantMap.delete(trimmedNumber);
         console.log(`${record.fields.name} has been unsubscribed`);
         const participantName = participant["name"];
         await sendSingleSMS(

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,8 +9,6 @@ const twilio = require("twilio");
 const tableName = "test";
 
 // to do:
-// rip out dotenv related code
-// TEST SUBSCRIBE FLOW TO MAKE SURE IT STILL WORKS
 // will implement group chat in a separate / future PR
 
 // memoize this because why the fuck not
@@ -25,7 +23,7 @@ const getBase = () => {
   return base;
 };
 
-// returns a map of {"+15555555", {name: 'tilde', airtableRecordId: '12345'} for all subscribed participants
+// returns a map of {"+15556667777", {name: 'tilde', airtableRecordId: '12345'} for all subscribed participants
 // phone numbers as always in e.164 format cuz I've got STANDARDS ok
 async function getAllSubscribedParticipants(base, tableName) {
   const participants = new Map();


### PR DESCRIPTION
## in this pr:
- rip out `dotenv`. it was supposed make dealing env variables easier during development, but it made running the `broadCastSMS` script a pain in the ass.
- add a util file where the code that's shared between scripts and server can live.
- add a script for sending a SMS broadcast.
- add ability for event participants to unsubscribe themselves from further communications.
- adds the ability to write/read from an airtable "test" table so that we're not spamming our participants during development or fucking up our "prod" data.

## test plan:
- Made API call with Postman to verify that hitting the unsubscribe endpoint checks that column in the test table.
- hooked a test phone number up to a Twilio Studio flow that pings the unsubscribe endpoint. Verified that unsubscribe box was checked
- ran `broadCastSMS` script on my local machine. Verified that SMS was sent to phone numbers in the test table.