### PR TITLE
feat: add group chat

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -45,8 +45,7 @@ app.post("/api/messages", async (request, response, next) => {
 
   const messageBody = request.body.Body;
   try {
-    // TODO: should this be .contains? probablyyyyyyy
-    if (messageBody.toLowerCase() === "unsubscribe") {
+    if (messageBody.toLowerCase().includes("unsubscribe")) {
       await unsubscribeParticipant(
         request.body.From,
         base,

--- a/src/server.js
+++ b/src/server.js
@@ -17,7 +17,6 @@ app.use(bodyParser.json());
 app.use(express.static(__dirname + "/public"));
 
 const base = getBase();
-let subscribedParticipants;
 
 // add a new participant to the Airtable base
 app.post("/api/participants", (request, response) => {
@@ -39,18 +38,17 @@ app.post("/api/participants", (request, response) => {
 });
 
 app.post("/api/messages", async (request, response, next) => {
-  if (!subscribedParticipants) {
-    subscribedParticipants = await getAllSubscribedParticipants(
-      base,
-      tableName
-    );
-  }
+  const subscribedParticipants = await getAllSubscribedParticipants(
+    base,
+    tableName
+  );
+
   const messageBody = request.body.Body;
   try {
     // TODO: should this be .contains? probablyyyyyyy
     if (messageBody.toLowerCase() === "unsubscribe") {
       await unsubscribeParticipant(
-        request.body.phone,
+        request.body.From,
         base,
         subscribedParticipants
       );
@@ -70,10 +68,14 @@ app.post("/api/messages", async (request, response, next) => {
 });
 
 // this isn't proper RESTful API design
-// but you can only GET and POST with twilio studio anyway
+// but you can only GET and POST with twilio anyway
 // and I'm kind of out of fucks at the moment so YOLO
 app.post("/api/participants/unsubscribe", async (request, response, next) => {
-  // TODO: get the subscribed participants
+  const subscribedParticipants = await getAllSubscribedParticipants(
+    base,
+    tableName
+  );
+
   try {
     await unsubscribeParticipant(
       request.body.phone,

--- a/src/server.js
+++ b/src/server.js
@@ -39,6 +39,9 @@ app.post("/api/participants", (request, response) => {
 });
 
 app.post("/api/messages", async (request, response, next) => {
+  console.log(request.body);
+  response.status(200).send("successful unsubscribe");
+
   if (!subscribedParticipants) {
     subscribedParticipants = await getAllSubscribedParticipants(
       base,
@@ -60,11 +63,11 @@ app.post("/api/messages", async (request, response, next) => {
     }
     response.status(200).send("successful unsubscribe");
   } else {
-    // senderPhoneNumber, messageBody, participantMap;
     await broadcastGroupChatMessage(
       request.body.From,
       messageBody,
-      subscribedParticipants
+      subscribedParticipants,
+      request.body.MediaUrl0
     );
   }
 });

--- a/src/server.js
+++ b/src/server.js
@@ -39,9 +39,6 @@ app.post("/api/participants", (request, response) => {
 });
 
 app.post("/api/messages", async (request, response, next) => {
-  console.log(request.body);
-  response.status(200).send("successful unsubscribe");
-
   if (!subscribedParticipants) {
     subscribedParticipants = await getAllSubscribedParticipants(
       base,
@@ -49,26 +46,26 @@ app.post("/api/messages", async (request, response, next) => {
     );
   }
   const messageBody = request.body.Body;
-  // should this be .contains? probablyyyyyyy
-  if (messageBody.toLowerCase() === "unsubscribe") {
-    try {
+  try {
+    // TODO: should this be .contains? probablyyyyyyy
+    if (messageBody.toLowerCase() === "unsubscribe") {
       await unsubscribeParticipant(
         request.body.phone,
         base,
         subscribedParticipants
       );
-    } catch (error) {
-      console.error("unsubscribe request failed", error);
-      return next(error);
+      response.status(200).send("successful unsubscribe");
+    } else {
+      await broadcastGroupChatMessage(
+        request.body.From,
+        messageBody,
+        subscribedParticipants,
+        request.body.MediaUrl0
+      );
     }
-    response.status(200).send("successful unsubscribe");
-  } else {
-    await broadcastGroupChatMessage(
-      request.body.From,
-      messageBody,
-      subscribedParticipants,
-      request.body.MediaUrl0
-    );
+  } catch (error) {
+    console.error(error);
+    return /* thank u, */ next(error);
   }
 });
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -20,9 +20,17 @@ const getBase = () => {
   return base;
 };
 
+// the revolution will not be memoized
+// i mean will! it will be memoized!
+// for real tho, lookin up all the participants is expensive.
+let subscribedParticipants = null;
+
 // returns a map of {"+15556667777", {name: 'tilde', airtableRecordId: '12345'} for all subscribed participants
 // phone numbers as always in e.164 format cuz I've got STANDARDS ok
-async function getAllSubscribedParticipants(base, tableName) {
+const getAllSubscribedParticipants = async (base, tableName) => {
+  if (subscribedParticipants !== null) {
+    return subscribedParticipants;
+  }
   const participants = new Map();
 
   // TODO: i am not sure .all will work if we get above 100 participants
@@ -42,8 +50,9 @@ async function getAllSubscribedParticipants(base, tableName) {
       });
     }
   });
+  subscribedParticipants = participants;
   return participants;
-}
+};
 
 const twilioNumber = "+1 415 430 9656";
 const twilioClient = twilio(
@@ -64,7 +73,6 @@ async function sendSingleSMS(toNumber, messageBody, mediaURL = null) {
 }
 
 // TODO:
-// test subscribe flow to make sure body-parser hasn't fucked anything up
 // tackle misc TODOs and cleanup littering this code base like tiny weeds
 // end to end testing? (we probably want to do this with at least 3 actual phone numbers + ngrok, before merging)
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -51,14 +51,16 @@ const twilioClient = twilio(
   process.env.TWILIO_AUTH_TOKEN
 );
 
-async function sendSingleSMS(toNumber, messageBody) {
+async function sendSingleSMS(toNumber, messageBody, mediaURL = null) {
   // TODO: uncomment when you're done testing but no need to spam people right now
-  await console.log(toNumber, messageBody);
-  // await twilioClient.messages.create({
-  //   to: toNumber,
-  //   from: twilioNumber,
-  //   body: messageBody,
-  // });
+  const parameters = { to: toNumber, from: twilioNumber, body: messageBody };
+  if (mediaURL !== null) {
+    // ugh why doesn't twilio capitalize URL correctly in their API?
+    // if only I knew somebody who worked there so I could complain
+    parameters.mediaUrl = [mediaURL];
+  }
+  await console.log("!!!!! PARAMETERS", parameters);
+  // await twilioClient.messages.create({ parameters });
 }
 
 // TODO:
@@ -70,7 +72,8 @@ async function sendSingleSMS(toNumber, messageBody) {
 async function broadcastGroupChatMessage(
   senderPhoneNumber,
   messageBody,
-  participantMap
+  participantMap,
+  mediaURL = null
 ) {
   const trimmedNumber = senderPhoneNumber.trim();
 
@@ -88,7 +91,7 @@ async function broadcastGroupChatMessage(
       // we don't need to send the sender a copy of their own message.
       continue;
     } else {
-      await sendSingleSMS(phoneNumber, messageBodyWithName);
+      await sendSingleSMS(phoneNumber, messageBodyWithName, mediaURL);
     }
   }
 }
@@ -132,21 +135,6 @@ async function unsubscribeParticipant(phoneNumber, base, participantMap) {
     }
   );
 }
-
-// just for testing, will remove before merging
-// (async function () {
-//   const subscribedParticipants = await getAllSubscribedParticipants(
-//     getBase(),
-//     tableName
-//   );
-
-//   // maybe broadcastGroupChatMessage is a better name??
-//   await broadcastGroupChatMessage(
-//     "+12345678901",
-//     "you rock",
-//     subscribedParticipants
-//   );
-// })();
 
 module.exports = {
   broadcastGroupChatMessage,

--- a/src/utils.js
+++ b/src/utils.js
@@ -64,10 +64,9 @@ async function sendSingleSMS(toNumber, messageBody, mediaURL = null) {
 }
 
 // TODO:
-// test error handling
-// error handling for send SMS functionality?
 // test subscribe flow to make sure body-parser hasn't fucked anything up
-// end to end testing? (we probably want to do this with at least 3 actual phone numbers)
+// tackle misc TODOs and cleanup littering this code base like tiny weeds
+// end to end testing? (we probably want to do this with at least 3 actual phone numbers + ngrok, before merging)
 
 async function broadcastGroupChatMessage(
   senderPhoneNumber,

--- a/src/utils.js
+++ b/src/utils.js
@@ -61,6 +61,12 @@ async function sendSingleSMS(toNumber, messageBody) {
   // });
 }
 
+// TODO:
+// test error handling
+// error handling for send SMS functionality?
+// test subscribe flow to make sure body-parser hasn't fucked anything up
+// end to end testing? (we probably want to do this with at least 3 actual phone numbers)
+
 async function broadcastGroupChatMessage(
   senderPhoneNumber,
   messageBody,
@@ -143,6 +149,7 @@ async function unsubscribeParticipant(phoneNumber, base, participantMap) {
 // })();
 
 module.exports = {
+  broadcastGroupChatMessage,
   getAllSubscribedParticipants,
   getBase,
   tableName,

--- a/src/utils.js
+++ b/src/utils.js
@@ -26,7 +26,7 @@ const getBase = () => {
 let subscribedParticipants = null;
 
 // returns a map of {"+15556667777", {name: 'tilde', airtableRecordId: '12345'} for all subscribed participants
-// phone numbers as always in e.164 format cuz I've got STANDARDS ok
+// phone numbers in e.164 format cuz I've got STANDARDS
 const getAllSubscribedParticipants = async (base, tableName) => {
   if (subscribedParticipants !== null) {
     return subscribedParticipants;
@@ -34,6 +34,7 @@ const getAllSubscribedParticipants = async (base, tableName) => {
   const participants = new Map();
 
   // TODO: i am not sure .all will work if we get above 100 participants
+  // airtable docs says that's the max page size??
   // if we get that far let's make sure to test it out
   const records = await base(tableName).select().all();
   records.map((record) => {
@@ -73,9 +74,7 @@ async function sendSingleSMS(toNumber, messageBody, mediaURL = null) {
 }
 
 // TODO:
-// tackle misc TODOs and cleanup littering this code base like tiny weeds
-// do we want to close subscriptions after everyone arrives? Probably we do.
-// end to end testing? (we probably want to do this with at least 3 actual phone numbers + ngrok, before merging)
+// end to end testing with at least 3 actual phone numbers + ngrok, before merging
 
 async function broadcastGroupChatMessage(
   senderPhoneNumber,
@@ -87,6 +86,8 @@ async function broadcastGroupChatMessage(
 
   const participant = participantMap.get(trimmedNumber);
   if (!participant) {
+    // todo: this probably shouldn't be a thrown error
+    // if people text the group chat after they're unsubscribed, just tell them they can't.
     throw new Error(`participant ${trimmedNumber} not found`);
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -74,6 +74,7 @@ async function sendSingleSMS(toNumber, messageBody, mediaURL = null) {
 
 // TODO:
 // tackle misc TODOs and cleanup littering this code base like tiny weeds
+// do we want to close subscriptions after everyone arrives? Probably we do.
 // end to end testing? (we probably want to do this with at least 3 actual phone numbers + ngrok, before merging)
 
 async function broadcastGroupChatMessage(

--- a/src/utils.js
+++ b/src/utils.js
@@ -62,19 +62,14 @@ const twilioClient = twilio(
 );
 
 async function sendSingleSMS(toNumber, messageBody, mediaURL = null) {
-  // TODO: uncomment when you're done testing but no need to spam people right now
   const parameters = { to: toNumber, from: twilioNumber, body: messageBody };
   if (mediaURL !== null) {
     // ugh why doesn't twilio capitalize URL correctly in their API?
     // if only I knew somebody who worked there so I could complain
     parameters.mediaUrl = [mediaURL];
   }
-  await console.log("!!!!! PARAMETERS", parameters);
-  // await twilioClient.messages.create({ parameters });
+  await twilioClient.messages.create({ parameters });
 }
-
-// TODO:
-// end to end testing with at least 3 actual phone numbers + ngrok, before merging
 
 async function broadcastGroupChatMessage(
   senderPhoneNumber,
@@ -86,9 +81,9 @@ async function broadcastGroupChatMessage(
 
   const participant = participantMap.get(trimmedNumber);
   if (!participant) {
-    // todo: this probably shouldn't be a thrown error
-    // if people text the group chat after they're unsubscribed, just tell them they can't.
-    throw new Error(`participant ${trimmedNumber} not found`);
+    // if a participant unsubscribes but tries to broadcast a message, we could end up here.
+    // no need to throw an error 'cuz it may happen, just don't pass their message through.
+    console.log(`participant ${trimmedNumber} not found`);
   }
 
   const participantName = participant["name"];

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,7 +6,7 @@ const twilio = require("twilio");
 // this const is so that we can easily read/write from a test table under development
 // and not mess with "prod" data.
 // change this const to "participants" when you're ready to party.
-const tableName = "test";
+const tableName = "participants";
 
 // memoize this because why the fuck not
 //  THERE CAN BE ONLY ONE BASE
@@ -55,20 +55,30 @@ const getAllSubscribedParticipants = async (base, tableName) => {
   return participants;
 };
 
-const twilioNumber = "+1 415 430 9656";
+const twilioNumber = "+1 707 348 5740";
 const twilioClient = twilio(
   process.env.TWILIO_ACCOUNT_SID,
   process.env.TWILIO_AUTH_TOKEN
 );
 
 async function sendSingleSMS(toNumber, messageBody, mediaURL = null) {
-  const parameters = { to: toNumber, from: twilioNumber, body: messageBody };
   if (mediaURL !== null) {
     // ugh why doesn't twilio capitalize URL correctly in their API?
     // if only I knew somebody who worked there so I could complain
-    parameters.mediaUrl = [mediaURL];
+    // parameters.mediaUrl = [mediaURL];
+    await twilioClient.messages.create({
+      to: toNumber,
+      from: twilioNumber,
+      body: messageBody,
+      mediaUrl: [mediaURL],
+    });
   }
-  await twilioClient.messages.create({ parameters });
+
+  await twilioClient.messages.create({
+    to: toNumber,
+    from: twilioNumber,
+    body: messageBody,
+  });
 }
 
 async function broadcastGroupChatMessage(


### PR DESCRIPTION
Houston, we have a group chat. 🚀 (God, I'm sorry. Well, that was a lie. I'm really not.)

Anyway, this pr:
- adds an endpoint to broadcast messages to all subscribed participants in the airtable
- adds support for media messages 📸 
- adds special case to handle messages that contain the substring "unsubscribe", which triggers...you guessed it...the unsubscribe flow
- adds a cached copy of the `subscribedParticipants` map on the server side, which should stay in sync with the airtable back end
- tidies up the error handling a bit 💩 

## test plan
- verify subscribe flow still works after this refactor
- verified that text messages which are sent by a participant have the participant's name prepended, and are then broadcast to all other subscribed participants
- verified that media messages which are sent by a participant have the participant's name prepended, and are then broadcast to all other subscribed participants
- verified that messages which contain the substring "unsubscribe" trigger the unsubscribe flow and mark the participant as unsubscribed in airtable

## todo before merging
✅ end to end test this with 3 real live phone numbers just in case something is wack
✅ change the name of the table from `test` to `participants` SRSLY DO NOT FORGET. (I mean, the worst case is that if I forget, we have to copy some data from one table to another but I'd like to avoid that if possible.)