### PR TITLE
remove group chat API endpoint

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -48,43 +48,6 @@ app.post("/api/participants", async (request, response, next) => {
   );
 });
 
-const vaporloopVoiceOfGodNumber = "+17073485740";
-app.post("/api/messages", async (request, response, next) => {
-  const subscribedParticipants = await getAllSubscribedParticipants(
-    base,
-    tableName
-  );
-
-  const messageBody = request.body.Body;
-  try {
-    // special case: we need to be able to tell participants how to unsubscribe
-    // if the voice of god sends a message containing the text "unsubscribe"
-    // don't actually unsubscribe!!
-    if (
-      request.body.From !== vaporloopVoiceOfGodNumber &&
-      messageBody.toLowerCase().includes("unsubscribe")
-    ) {
-      await unsubscribeParticipant(
-        request.body.From,
-        base,
-        subscribedParticipants
-      );
-      response.status(200).send("successful unsubscribe");
-    } else {
-      await broadcastGroupChatMessage(
-        request.body.From,
-        messageBody,
-        subscribedParticipants,
-        request.body.MediaUrl0
-      );
-      response.status(200).send("message broadcasted successfully");
-    }
-  } catch (error) {
-    console.error(error);
-    return /* thank u, */ next(error);
-  }
-});
-
 // this isn't proper RESTful API design
 // but you can only GET and POST with twilio anyway
 // and I'm kind of out of fucks at the moment so YOLO


### PR DESCRIPTION
VAPORLOOP  ̵i̵s̸ ̵d̷e̷a̶d̷,̵ l̷͚̣̂̈́͆͘ó̵̫͓̰͓̮n̴̜͙̬̓͊͛́̀͝ģ̴̰͉̫͎̀̔̿ͅ ̵̼̻̟̽l̶̡̰̋͐̍į̴̱̣̪͎͎͐̃̀̿̕v̶̜̱̤̪̈́̃̔e̵̢͍̖͗̒̋͗͘ V̷̡̧̫̮̞̰̎̾̅̒̔̂͊̅͒͘̚͝À̴͍̗̮͕̞̘͇̰̂̍̉̄͂͋̔͗͑͋̕ͅP̷̨̮͔̰̤̺̲̖̳͛͘Õ̷̺̙͛̽̈́̒͝͝R̸̬̮̣͍͎̄͝L̷̻͎̋̾́̈́̀O̶͙̤̬̺͍̭̼͇̗̩̿͑͆͋̀͠Ǒ̴̧͔͎̭͕̹͕͔̥̫̙́̊̔̔̍̚̕͝P̶̺̞̖̣̣̬̟͕̎̈́.

We came. We saw. The event was great. It is over. 

We have shut down the group chat, so, we don't want to leave the API endpoint open, because otherwise some asshole could spam the group chat by abusing this api and we don't want that now do we.