### PR TITLE
vaporloop is alive, long live vaporloop

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,6 @@ npm start
 
 ## Deploying the application
 
-The app is automatically deployed to Heroku when new branches are merged in to master.
+The app is automatically deployed to Heroku when new branches are merged in to main.
 
 If you add new environment variables, you'll need to add them to the Heroku console in order for the app to run correctly.

--- a/src/scripts/joinRandomModeratedConference.js
+++ b/src/scripts/joinRandomModeratedConference.js
@@ -1,0 +1,46 @@
+/* this serverless function handles two moderated conferences
+    if you're a moderator, you join your specific conference.
+    if you're a participant, you join a random one, whee.
+*/ 
+
+const moderatorInfo = [
+    // phone numbers have been changed to protect the guilty parties
+  { name: "randall", number: "+12345678900" },
+  { name: "jemma", number: "+19876543210" },
+];
+
+// a little light hold music 🎶 or a personalized greeting for mods
+const looperWaitUrl =
+  "https://handler.twilio.com/twiml/EHda8529556c6a4b5e2f023b41af5d6724";
+
+const moderatorWaitUrl =
+  "https://handler.twilio.com/twiml/EH7571e0cfd713cc79a7bc6cc283a6df26";
+
+
+exports.handler = function (context, event, callback) {
+  const twiml = new Twilio.twiml.VoiceResponse();
+  moderatorInfo.forEach((mod) => {
+    // if the moderator is calling, join their specific conference
+    if (event.From === mod.number) {
+      moderatorPhoneNumber = mod.number;
+      twiml.dial().conference(mod.name, {
+        // the party don't start till you walk in
+        // but please don't brush your teeth with a bottle of jack, this is a family game.
+        startConferenceOnEnter: true,
+        endConferenceOnExit: true,
+        waitUrl: moderatorWaitUrl,
+      });
+      callback(null, twiml);
+    }
+  });
+  // rollin the dice 🎲 to see which moderator you're gonna get
+  const moderator =
+    moderatorInfo[Math.floor(Math.random() * Math.floor(moderatorInfo.length))];
+  const conferenceName = moderator.name;
+
+  twiml.dial().conference(conferenceName, {
+    startConferenceOnEnter: false,
+    waitUrl: looperWaitUrl,
+  });
+  callback(null, twiml);
+};

--- a/src/scripts/sendSignupNotificationEmail.js
+++ b/src/scripts/sendSignupNotificationEmail.js
@@ -1,0 +1,60 @@
+/** A serverless function that sends an email to event organizers to notify them of new signups. 
+*/
+
+exports.handler = function (context, event, callback) {
+    const sgMail = require("@sendgrid/mail");
+    sgMail.setApiKey(context.SENDGRID_API_KEY);
+    const text = getMessageText();
+  
+    const message = {
+      // If you are reading this, you can look at our Git commit history and find our email addresses
+      // so I don't see the point in obscuring them here.
+      // if I cared, I could parameterize these or pass them in via context or something. 
+      to: ["tilde@thuryism.net", "katekz@gmail.com"],
+      from: "tilde@thuryism.net",
+      subject: `${event.participantName} has signed up for vaporloop!`,
+      text,
+    };
+    sgMail
+      .send(message)
+      .then(() => {
+        callback(null, "Email sent successfully");
+      })
+      .catch((e) => {
+        console.log(e);
+      });
+  };
+  
+  const getMessageText = () => {
+    const vaporwaveEmoji = [
+      "💙",
+      "💜",
+      "💖",
+      "😎",
+      "🦕",
+      "🍕",
+      "🛹",
+      "🎶",
+      "🎛",
+      "🎚",
+      "➰",
+      "🦝",
+      "🔥",
+      "💟",
+      "▶",
+    ];
+    const congratsText = [
+      "wooohooo!",
+      "NOICE",
+      "well done",
+      "hell yeah",
+      "this is so exciting",
+    ];
+    const emoji = vaporwaveEmoji
+      .sort(() => Math.random() - Math.random())
+      .slice(0, 3)
+      .join(" ");
+    const text =
+      congratsText[Math.floor(Math.random() * Math.floor(congratsText.length))];
+    return `${text} ${emoji}`;
+  };

--- a/src/server.js
+++ b/src/server.js
@@ -48,6 +48,43 @@ app.post("/api/participants", async (request, response, next) => {
   );
 });
 
+const vaporloopVoiceOfGodNumber = "+17073485740";
+app.post("/api/messages", async (request, response, next) => {
+  const subscribedParticipants = await getAllSubscribedParticipants(
+    base,
+    tableName
+  );
+
+  const messageBody = request.body.Body;
+  try {
+    // special case: we need to be able to tell participants how to unsubscribe
+    // if the voice of god sends a message containing the text "unsubscribe"
+    // don't actually unsubscribe!!
+    if (
+      request.body.From !== vaporloopVoiceOfGodNumber &&
+      messageBody.toLowerCase().includes("unsubscribe")
+    ) {
+      await unsubscribeParticipant(
+        request.body.From,
+        base,
+        subscribedParticipants
+      );
+      response.status(200).send("successful unsubscribe");
+    } else {
+      await broadcastGroupChatMessage(
+        request.body.From,
+        messageBody,
+        subscribedParticipants,
+        request.body.MediaUrl0
+      );
+      response.status(200).send("message broadcasted successfully");
+    }
+  } catch (error) {
+    console.error(error);
+    return /* thank u, */ next(error);
+  }
+});
+
 // this isn't proper RESTful API design
 // but you can only GET and POST with twilio anyway
 // and I'm kind of out of fucks at the moment so YOLO

--- a/src/server.js
+++ b/src/server.js
@@ -48,6 +48,10 @@ app.post("/api/participants", async (request, response, next) => {
   );
 });
 
+/** This endpoint is currently deprecated 🐬😭
+ * leaving this function here for readability
+ * since I'm presenting a short demo about how the application worked during its glory days.
+ */
 const vaporloopVoiceOfGodNumber = "+17073485740";
 app.post("/api/messages", async (request, response, next) => {
   const subscribedParticipants = await getAllSubscribedParticipants(

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,11 +2,12 @@
 const airtable = require("airtable");
 const twilio = require("twilio");
 
-// TODO: change this before you merge!!
+
 // this const is so that we can easily read/write from a test table under development
 // and not mess with "prod" data.
 // change this const to "participants" when you're ready to party.
-const tableName = "participants";
+// could have made this an enviornment variable, I guess? 🤷🏻‍♂️
+const tableName = "test";
 
 // memoize this because why the fuck not
 //  THERE CAN BE ONLY ONE BASE


### PR DESCRIPTION
Bringing this back like it's 2020, for the purposes of a smol demo. 

- port the code from serverless functions into the `/scripts` folder, just so that it can live in a version controlled universe instead of a Twilio sandbox (where these were actually running.)
- revive the code to broadcast a message to the group, purely for readability.
- Change to use the `test` airtable instead of production. On the very small chance someone sends a SMS message to the VAPORLOOP group chat from 2020, this change avoids spamming that message to the group of our old players. 
- change `master` to `main` in the README because language inclusivity matters